### PR TITLE
fix: 강의평 버튼 클릭 기능 수정

### DIFF
--- a/src/components/page/Home/home-button.tsx
+++ b/src/components/page/Home/home-button.tsx
@@ -22,7 +22,7 @@ const HomeButton = () => {
             </div>
             <div className='home-wrapper'>
                 <div className="home-button">
-                    <Link href="/review-register-page" className='home-link-align'>
+                    <Link href="/course-page" className='home-link-align'>
                         <img src="img/stack-of-books.png" alt="강의평" />
                         강의평
                     </Link>

--- a/src/utill/axios.ts
+++ b/src/utill/axios.ts
@@ -12,10 +12,10 @@ export const api = axios.create({
 })
 
 if (ENV === 'development') {
-    // const mockAxios = new MockAdapter(api)
-    // mockAxios.onGet(API.COURSER_REVIEW).reply(200, mockFormData_Review)
-    // mockAxios.onGet(API.SHOW_TIMETABLE).reply(200, mockCourses)
-    // mockAxios.onPost(API.REVIEW_REGISTER).reply(201)
+    const mockAxios = new MockAdapter(api)
+    mockAxios.onGet(API.COURSER_REVIEW).reply(200, mockFormData_Review)
+    mockAxios.onGet(API.SHOW_TIMETABLE).reply(200, mockCourses)
+    mockAxios.onPost(API.REVIEW_REGISTER).reply(201)
 } 
 // dev환경에서 백엔드 post요청할 때는 막아놓기.
 // 나중에 npm build할 때 세미콜론 등 다른 오류 고쳐야 돌아갈 수 있음.


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #4 

## 📝작업 내용

> 강의평 버튼 클릭 시 강의평 등록 -> 강의평 검색 페이지로 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
