### PR TITLE
feat: 강의평 버튼 클릭 시 courseid 인자 넘겨주기

### DIFF
--- a/src/app/review-page/[course_name]/[professor]/page.tsx
+++ b/src/app/review-page/[course_name]/[professor]/page.tsx
@@ -19,9 +19,12 @@ const ReviewPage = () => {
   console.log('course_name:', courseNameStr);
   console.log('professor:', professorStr);
 
+  // 예시로 courseId를 1로 설정 (실제로는 데이터에서 가져와야 함)
+  const courseId = 1;
+
   return (
     <Page title="ReviewPage">
-      <Header />
+      <Header courseId={courseId} />
       {courseNameStr && professorStr && (
         <>
           <AverageStar courseName={courseNameStr} professor={professorStr} />

--- a/src/components/page/Review/header.tsx
+++ b/src/components/page/Review/header.tsx
@@ -1,7 +1,18 @@
 import { Typography, Button, Grid, Link } from "@mui/material";
+import { useRouter } from 'next/navigation';
 import 'styles/review-register.css';
 
-const Header = () => {
+interface HeaderProps {
+  courseId: number;
+}
+
+const Header = ({ courseId }: HeaderProps) => {
+  const router = useRouter();
+
+  const handleReviewClick = () => {
+    router.push(`/review-register-page/${courseId}`);
+  };
+
   return (
     <Grid container className="header-container" alignItems="center">
       <Grid item xs={4}></Grid>
@@ -11,11 +22,9 @@ const Header = () => {
         </Typography>
       </Grid>
       <Grid item xs={4} container justifyContent="flex-end">
-        <Link href="#">
-          <Button variant="contained" className="rating-button">
-            평가하기
-          </Button>
-        </Link>
+        <Button variant="contained" className="rating-button" onClick={handleReviewClick}>
+          평가하기
+        </Button>
       </Grid>
     </Grid>
   );

--- a/src/utill/axios.ts
+++ b/src/utill/axios.ts
@@ -12,10 +12,10 @@ export const api = axios.create({
 })
 
 if (ENV === 'development') {
-    // const mockAxios = new MockAdapter(api)
-    // mockAxios.onGet(API.COURSER_REVIEW).reply(200, mockFormData_Review)
-    // mockAxios.onGet(API.SHOW_TIMETABLE).reply(200, mockCourses)
-    // mockAxios.onPost(API.REVIEW_REGISTER).reply(201)
+    const mockAxios = new MockAdapter(api)
+    mockAxios.onGet(API.COURSER_REVIEW).reply(200, mockFormData_Review)
+    mockAxios.onGet(API.SHOW_TIMETABLE).reply(200, mockCourses)
+    mockAxios.onPost(API.REVIEW_REGISTER).reply(201)
 } 
 // dev환경에서 백엔드 post요청할 때는 막아놓기.
 // 나중에 npm build할 때 세미콜론 등 다른 오류 고쳐야 돌아갈 수 있음.


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 강의평 버튼 클릭 시 강의평 등록 페이지로 path variable로 인자를 넘겨주는 방식의 기능을 작업하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
